### PR TITLE
[#6] Capture force push events

### DIFF
--- a/src/handler/githubToTrello.js
+++ b/src/handler/githubToTrello.js
@@ -27,12 +27,13 @@ function getShortLink(body, githubEvent) {
 function getPushMessage(body) {
   if (body && body.repository && body.head_commit) {
     const repo = body.repository.name;
+    const forced = body.forced ? 'force pushed' : 'pushed';
     const pusher = body.pusher.name;
     const commitMessage = body.head_commit.message;
     const commitUrl = body.head_commit.url;
     const commitAuthor = body.head_commit.author.name;
     const shortHash = body.head_commit.id.substring(0, 7);
-    const message = `${pusher} pushed [${repo}/${shortHash}](${commitUrl})\n\n${commitMessage}\n\nby *${commitAuthor}*`;
+    const message = `${pusher} ${forced} [${repo}/${shortHash}](${commitUrl})\n\n${commitMessage}\n\nby *${commitAuthor}*`;
     return message;
   }
   throw new HTTPError(400, `No push message generated for ${body.ref}`);

--- a/test/handler/githubToTrello.test.js
+++ b/test/handler/githubToTrello.test.js
@@ -1,7 +1,10 @@
 const { githubToTrello } = require('../../src/handler/githubToTrello');
+const trello = require('../../src/util/trello');
 
 jest.mock('../../src/util/httpsRequest');
 const { httpsRequest } = require('../../src/util/httpsRequest');
+
+// trello.postComment = jest.fn();
 
 test('push', async () => {
   const req = {
@@ -18,8 +21,34 @@ test('push', async () => {
     },
   };
 
+  const trelloSpy = jest.spyOn(trello, 'postComment');
   httpsRequest.mockResolvedValue({ id: '560bf4df7139286471dc009e' });
   const request = await githubToTrello('push', req);
+  expect(trelloSpy).toHaveBeenCalledWith('nqPiDKmw', expect.stringMatching(/^josh pushed \[linguist/));
+  expect(request.body).toEqual({ id: '560bf4df7139286471dc009e' });
+  expect(request.location).toEqual('https://trello.com/c/nqPiDKmw/#comment-560bf4df7139286471dc009e');
+});
+
+test('force push', async () => {
+  const req = {
+    body: {
+      ref: 'refs/heads/nqPiDKmw/9-grand-canyon-national-park',
+      forced: true,
+      repository: { name: 'linguist' },
+      pusher: { name: 'josh' },
+      head_commit: {
+        id: 'd1fd61921892b63b7c142b07e25ce0b153739293',
+        message: 'Define Linguist module',
+        author: { name: 'josh' },
+        url: 'https://github.com/github/linguist/commit/d1fd61921892b63b7c142b07e25ce0b153739293',
+      },
+    },
+  };
+
+  const trelloSpy = jest.spyOn(trello, 'postComment');
+  httpsRequest.mockResolvedValue({ id: '560bf4df7139286471dc009e' });
+  const request = await githubToTrello('push', req);
+  expect(trelloSpy).toHaveBeenCalledWith('nqPiDKmw', expect.stringMatching(/^josh force pushed \[linguist/));
   expect(request.body).toEqual({ id: '560bf4df7139286471dc009e' });
   expect(request.location).toEqual('https://trello.com/c/nqPiDKmw/#comment-560bf4df7139286471dc009e');
 });


### PR DESCRIPTION
**Capture force push events**
* * *

# What does this Pull Request do?
Resolves #6: If the webhook payload includes `forced: true`, then update the comment text
to read `<user> force pushed ...`

# How should this be tested?
Push one commit, verify the comment.
Force push another commit, verify the comment message includes "force pushed"


# Checklist
- [x] Code contains tests for the feature/problem this PR is addressing
- [x] All tests pass
- [x] Your commits have been squashed/rebased/etc. for reviewer clarity



