### PR TITLE
[#8] Return 403 instead of 401 for X-Hub-Signature mis-match

### DIFF
--- a/src/util/github.js
+++ b/src/util/github.js
@@ -24,7 +24,7 @@ function verify(signature, body) {
     return true;
   }
   console.info(`Provided signature (${signature}) did not match payload signature (${payloadSignature})`);
-  throw new HTTPError(401, 'X-Hub-Signature mis-match');
+  throw new HTTPError(403, 'X-Hub-Signature mis-match');
 }
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -128,11 +128,11 @@ test('githubWebhookHandler POST pull_request with invalid signatures', async () 
 
   req.headers['x-hub-signature'] = 'x'.repeat(45);
   await githubWebhookHandler(req, mockRes);
-  expect(mockRes.statusCode).toBe(401);
+  expect(mockRes.statusCode).toBe(403);
   expect(mockRes.message).toBe('X-Hub-Signature mis-match');
 
   req.headers['x-hub-signature'] = 'foo';
   await githubWebhookHandler(req, mockRes);
-  expect(mockRes.statusCode).toBe(401);
+  expect(mockRes.statusCode).toBe(403);
   expect(mockRes.message).toBe('X-Hub-Signature mis-match');
 });

--- a/test/util/github.test.js
+++ b/test/util/github.test.js
@@ -14,21 +14,24 @@ test('getBranchName', () => {
 });
 
 test('validateWebhook with missing parameters', () => {
-  expect(() => validateWebhook()).toThrowError(/^Bad Request$/);
-  expect(() => validateWebhook({ headers: null, body: null })).toThrowError(/^Bad Request$/);
-  expect(() => validateWebhook({ headers: {} })).toThrowError(/^Bad Request$/);
-  expect(() => validateWebhook({
-    headers: {},
-    body: {},
-  })).toThrowError(/^Must provide X-Hub-Signature header$/);
-  expect(() => validateWebhook({
-    headers: { 'x-hub-signature': 'x' },
-    body: {},
-  })).toThrowError(/^Must provide X-GitHub-Event header$/);
-  expect(() => validateWebhook({
-    headers: { 'x-hub-signature': 'x', 'x-github-event': 'y' },
-    body: {},
-  })).toThrowError(/^Must provide X-GitHub-Delivery header$/);
+  expect(() => validateWebhook()).toThrowError(
+    expect.objectContaining({ statusCode: 400, message: 'Bad Request' }),
+  );
+  expect(() => validateWebhook({ body: null })).toThrowError(
+    expect.objectContaining({ statusCode: 400, message: 'Bad Request' }),
+  );
+  expect(() => validateWebhook({ headers: {} })).toThrowError(
+    expect.objectContaining({ statusCode: 400, message: 'Bad Request' }),
+  );
+  expect(() => validateWebhook({ headers: {}, body: {} })).toThrowError(
+    expect.objectContaining({ statusCode: 400, message: 'Must provide X-Hub-Signature header' }),
+  );
+  expect(() => validateWebhook({ headers: { 'x-hub-signature': 'x' }, body: {} })).toThrowError(
+    expect.objectContaining({ statusCode: 400, message: 'Must provide X-GitHub-Event header' }),
+  );
+  expect(() => validateWebhook({ headers: { 'x-hub-signature': 'x', 'x-github-event': 'y' }, body: {} })).toThrowError(
+    expect.objectContaining({ statusCode: 400, message: 'Must provide X-GitHub-Delivery header' }),
+  );
 });
 
 test('validateWebhook signature verification', () => {
@@ -46,7 +49,9 @@ test('validateWebhook signature verification', () => {
       'x-github-delivery': 'z',
     },
     body: { foo: 'bar' },
-  })).toThrowError(/^X-Hub-Signature mis-match$/);
+  })).toThrowError(
+    expect.objectContaining({ statusCode: 403, message: 'X-Hub-Signature mis-match' }),
+  );
 
   expect(validateWebhook({
     headers: {


### PR DESCRIPTION

# What does this Pull Request do?
Resolves #8. Returns a 403 instead of 401 for signature mis-match.
Also adds more complete tests for both status code and message.

# What's new?
One-character change: `1` to `3`. However, the tests now allow for checking both the status code and message, where before we were just checking the message.

# How should this be tested?

`test/index.test.js`


# Checklist
- [x] Code contains tests for the feature/problem this PR is addressing
- [x] All tests pass
- [x] Your commits have been squashed/rebased/etc. for reviewer clarity


# Additional Notes:
- https://tools.ietf.org/html/rfc7231#section-6.5.3
- https://stackoverflow.com/questions/3297048/403-forbidden-vs-401-unauthorized-http-responses
