### PR TITLE
[#21] Flexible placement of Trello Card IDs

### DIFF
--- a/src/handler/githubToTrello.js
+++ b/src/handler/githubToTrello.js
@@ -16,8 +16,10 @@ function getShortLink(body, githubEvent) {
 
   if (!branch) {
     throw new HTTPError(400, `Unable to parse branch name for event: ${githubEvent}`);
-  } else if (branch.includes('#')) { // e.g., a branch like "my-branch-name#nqPiDKmw"
-    return branch.split('#').pop(); // The 8 character shortened ID for the card, e.g. "nqPiDKmw"
+  } else if (branch.charAt(branch.length - 9) === '#') { // e.g., a branch like "my-branch-name#nqPiDKmw"
+    return branch.slice(-8); // The 8 character shortened ID for the card, e.g. "nqPiDKmw"
+  } else if (branch.indexOf('/') === 8) { // e.g., a branch like "nqPiDKmw/9-grand-canyon-national-park"
+    return branch.slice(0, 8); // The 8 character shortened ID for the card, e.g. "nqPiDKmw"
   } else if (branch === 'master' || branch === 'develop') {
     throw new HTTPError(200, `Ignoring ${githubEvent} event for ${branch} branch`);
   }

--- a/test/handler/githubToTrello.test.js
+++ b/test/handler/githubToTrello.test.js
@@ -7,7 +7,7 @@ const { httpsRequest } = require('../../src/util/httpsRequest');
 
 // trello.postComment = jest.fn();
 
-test('push', async () => {
+test('push with shortLink at end', async () => {
   const req = {
     body: {
       ref: 'refs/heads/9-grand-canyon-national-park#nqPiDKmw',
@@ -30,10 +30,57 @@ test('push', async () => {
   expect(request.location).toEqual('https://trello.com/c/nqPiDKmw/#comment-560bf4df7139286471dc009e');
 });
 
-test('force push', async () => {
+test('push with shortLink at beginning', async () => {
+  const req = {
+    body: {
+      ref: 'refs/heads/nqPiDKmw/9-grand-canyon-national-park',
+      repository: { name: 'linguist' },
+      pusher: { name: 'josh' },
+      head_commit: {
+        id: 'd1fd61921892b63b7c142b07e25ce0b153739293',
+        message: 'Define Linguist module',
+        author: { name: 'josh' },
+        url: 'https://github.com/github/linguist/commit/d1fd61921892b63b7c142b07e25ce0b153739293',
+      },
+    },
+  };
+
+  const trelloSpy = jest.spyOn(trello, 'postComment');
+  httpsRequest.mockResolvedValue({ id: '560bf4df7139286471dc009e' });
+  const request = await githubToTrello('push', req);
+  expect(trelloSpy).toHaveBeenCalledWith('nqPiDKmw', expect.stringMatching(/^josh pushed \[linguist/));
+  expect(request.body).toEqual({ id: '560bf4df7139286471dc009e' });
+  expect(request.location).toEqual('https://trello.com/c/nqPiDKmw/#comment-560bf4df7139286471dc009e');
+});
+
+test('force push with shortLink at end', async () => {
   const req = {
     body: {
       ref: 'refs/heads/9-grand-canyon-national-park#nqPiDKmw',
+      forced: true,
+      repository: { name: 'linguist' },
+      pusher: { name: 'josh' },
+      head_commit: {
+        id: 'd1fd61921892b63b7c142b07e25ce0b153739293',
+        message: 'Define Linguist module',
+        author: { name: 'josh' },
+        url: 'https://github.com/github/linguist/commit/d1fd61921892b63b7c142b07e25ce0b153739293',
+      },
+    },
+  };
+
+  const trelloSpy = jest.spyOn(trello, 'postComment');
+  httpsRequest.mockResolvedValue({ id: '560bf4df7139286471dc009e' });
+  const request = await githubToTrello('push', req);
+  expect(trelloSpy).toHaveBeenCalledWith('nqPiDKmw', expect.stringMatching(/^josh force pushed \[linguist/));
+  expect(request.body).toEqual({ id: '560bf4df7139286471dc009e' });
+  expect(request.location).toEqual('https://trello.com/c/nqPiDKmw/#comment-560bf4df7139286471dc009e');
+});
+
+test('force push with shortLink at beginning', async () => {
+  const req = {
+    body: {
+      ref: 'refs/heads/nqPiDKmw/9-grand-canyon-national-park',
       forced: true,
       repository: { name: 'linguist' },
       pusher: { name: 'josh' },
@@ -60,12 +107,20 @@ test('unsupported event', async () => {
 });
 
 test('push with invalid body', async () => {
-  const req = {
+  let req;
+  req = {
     body: {
       ref: 'refs/heads/9-grand-canyon-national-park#nqPiDKmw',
     },
   };
   await expect(githubToTrello('push', req)).rejects.toThrow(/^No push message generated for refs\/heads\/9-grand-canyon-national-park#nqPiDKmw$/);
+
+  req = {
+    body: {
+      ref: 'refs/heads/nqPiDKmw/9-grand-canyon-national-park',
+    },
+  };
+  await expect(githubToTrello('push', req)).rejects.toThrow(/^No push message generated for refs\/heads\/nqPiDKmw\/9-grand-canyon-national-park$/);
 });
 
 test('push with invalid ref', async () => {
@@ -86,13 +141,62 @@ test('push on master', async () => {
   await expect(githubToTrello('push', req)).rejects.toThrow(/^Ignoring push event for master branch$/);
 });
 
-test('pull_request', async () => {
+test('pull_request with shortLink at end', async () => {
   const req = {
     body: {
       action: 'opened',
       pull_request: {
         html_url: 'https://github.com/github/linguist/pull/11',
         head: { ref: '9-grand-canyon-national-park#nqPiDKmw' },
+      },
+    },
+  };
+
+  httpsRequest
+    .mockReturnValueOnce({ id: '560bf4df7139286471dc009e' }) // postUrlAttachment
+    .mockReturnValueOnce({ id: '5b61cb39d057323aaa8500b8' }) // getBoardId
+    .mockReturnValueOnce([]) // getCustomFields
+    .mockReturnValueOnce({ // postCustomFields
+      id: '5b6be1a48dc4214d1313b650',
+      idModel: '5b61cb39d057323aaa8500b8',
+      modelType: 'board',
+      fieldGroup: '3ac58266f323d0ff02ab458154fe4e2fcf27d7c63beda514c5ab19cdbdf0558c',
+      display: { cardFront: true },
+      name: 'PR',
+      pos: 24576,
+      options: [
+        {
+          id: '5b6be1a48dc4214d1313b652',
+          idCustomField: '5b6be1a48dc4214d1313b650',
+          value: {
+            text: 'Open',
+          },
+          color: 'green',
+          pos: 36864,
+        },
+      ],
+      type: 'list',
+    })
+    .mockReturnValueOnce({ // putCustomFieldList
+      id: '5b6be1a48dc4214d1313b652',
+      idValue: '5b6be1a48dc4214d1313b653',
+      idCustomField: '5b6be1a48dc4214d1313b650',
+      idModel: '5b61cb39d057323aaa8500b8',
+      modelType: 'card',
+    });
+
+  const request = await githubToTrello('pull_request', req);
+  expect(request.body.id).toEqual('5b6be1a48dc4214d1313b652');
+  expect(request.location).toEqual('https://trello.com/c/nqPiDKmw');
+});
+
+test('pull_request with shortLink at beginning', async () => {
+  const req = {
+    body: {
+      action: 'opened',
+      pull_request: {
+        html_url: 'https://github.com/github/linguist/pull/11',
+        head: { ref: 'nqPiDKmw/9-grand-canyon-national-park' },
       },
     },
   };

--- a/test/util/httpError.test.js
+++ b/test/util/httpError.test.js
@@ -6,6 +6,6 @@ test('HTTPError', () => {
   expect(unauthorized.statusCode).toEqual(401);
 
   const teapot = new HTTPError(418);
-  expect(teapot.message).toEqual('I\'m a teapot');
+  expect(teapot.message.toLowerCase()).toEqual('I\'m a teapot'.toLowerCase()); // in Node 10, 'teapot' became 'Teapot'
   expect(teapot.statusCode).toEqual(418);
 });


### PR DESCRIPTION
**Flexible placement of Trello Card IDs**
* * *

# What does this Pull Request do?
Closes #27

Allow for the Trello Card ID to be placed at either the beginning or end of the branch name, e.g.:

* `nqPiDKmw/my-branch-name`
* `my-branch-name#nqPiDKmw`

# Checklist
- [x] Code contains tests for the feature/problem this PR is addressing
- [x] All tests pass
- [x] Your commits have been squashed/rebased/etc. for reviewer clarity
